### PR TITLE
Add dependency on nokogiri to gemspec

### DIFF
--- a/vagrant-xenserver.gemspec
+++ b/vagrant-xenserver.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.description   = "Enables Vagrant to manage XenServers."
 
   s.add_development_dependency "rake"
+  s.add_runtime_dependency "nokogiri", "~> 1.6.3"
 
   s.files         = `git ls-files`.split($\)
   s.executables   = [] # gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
prepare_nfs_settings.rb requires nokogiri, and will fail if it is
not available.   Adding this dependency causes 'vagrant plugin install
vagrant-xenserver' to install nokogiri in .vagrant.d/gems/gems, where it
can be used by the plugin.

Signed-off-by: Euan Harris <euan.harris@citrix.com>