### PR TITLE
Allow to set the name of the VM in the Vagrantfile

### DIFF
--- a/lib/vagrant-xenserver/action/create_vm.rb
+++ b/lib/vagrant-xenserver/action/create_vm.rb
@@ -31,7 +31,11 @@ module VagrantPlugins
           box_name = env[:machine].box.name.to_s
           box_version = env[:machine].box.version.to_s
 
-          vm_name = "#{username}/#{box_name}/#{box_version}"
+          if env[:machine].provider_config.name.nil?
+            vm_name = "#{username}/#{box_name}/#{box_version}"
+          else
+            vm_name = env[:machine].provider_config.name
+          end
 
           vm_ref = env[:xc].call("VM.clone",env[:session],oim,vm_name)['Value']
 

--- a/lib/vagrant-xenserver/config.rb
+++ b/lib/vagrant-xenserver/config.rb
@@ -18,6 +18,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :xs_password
 
+      # Name of the VM
+      #
+      # @return [String]
+      attr_accessor :name
+
       # True if the VM should be PV
       #
       # @return [Bool]
@@ -32,6 +37,7 @@ module VagrantPlugins
         @xs_host = UNSET_VALUE
         @xs_username = UNSET_VALUE
         @xs_password = UNSET_VALUE
+        @name = UNSET_VALUE
         @pv = UNSET_VALUE
         @memory = UNSET_VALUE
 	@xva_url = UNSET_VALUE
@@ -41,6 +47,7 @@ module VagrantPlugins
         @xs_host = nil if @xs_host == UNSET_VALUE
         @xs_username = nil if @xs_username == UNSET_VALUE
         @xs_password = nil if @xs_password == UNSET_VALUE
+        @name = nil if @name == UNSET_VALUE
         @pv = nil if @pv == UNSET_VALUE
         @memory = 1024 if @memory == UNSET_VALUE
 	@xva_url = nil if @xva_url = UNSET_VALUE


### PR DESCRIPTION
The name of the VM can be set in the Vagrantfile by means of xs.name.

If xs.name is not set, the traditional username/box_name/box_version
format is used.

Signed-off-by: Flavien Quesnel <flavien.quesnel@irt-systemx.fr>