### PR TITLE
Allow to set the port for communicating with XS API, and to use SSL/TLS

### DIFF
--- a/lib/vagrant-xenserver/action/connect_xs.rb
+++ b/lib/vagrant-xenserver/action/connect_xs.rb
@@ -12,7 +12,12 @@ module VagrantPlugins
 
         def call(env)
           if not env[:session]
-            env[:xc] = XMLRPC::Client.new(env[:machine].provider_config.xs_host, "/", "80")
+            env[:xc] = XMLRPC::Client.new3({
+              'host' => env[:machine].provider_config.xs_host,
+              'path' => "/",
+              'port' => env[:machine].provider_config.xs_port,
+              'use_ssl' => env[:machine].provider_config.xs_use_ssl
+            })
             
             @logger.info("Connecting to XenServer")
             

--- a/lib/vagrant-xenserver/config.rb
+++ b/lib/vagrant-xenserver/config.rb
@@ -8,6 +8,16 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :xs_host
 
+      # The port to communicate with the API on XenServer
+      #
+      # @return [Int]
+      attr_accessor :xs_port
+
+      # True if the API should be accessed over SSL/TLS
+      #
+      # @return [Bool]
+      attr_accessor :xs_use_ssl
+
       # The XenServer username
       #
       # @return [String]
@@ -30,6 +40,8 @@ module VagrantPlugins
 
       def initialize
         @xs_host = UNSET_VALUE
+        @xs_port = UNSET_VALUE
+        @xs_use_ssl = UNSET_VALUE
         @xs_username = UNSET_VALUE
         @xs_password = UNSET_VALUE
         @pv = UNSET_VALUE
@@ -39,6 +51,8 @@ module VagrantPlugins
 
       def finalize!
         @xs_host = nil if @xs_host == UNSET_VALUE
+        @xs_port = 80 if @xs_port == UNSET_VALUE
+        @xs_use_ssl = false if @xs_use_ssl == UNSET_VALUE
         @xs_username = nil if @xs_username == UNSET_VALUE
         @xs_password = nil if @xs_password == UNSET_VALUE
         @pv = nil if @pv == UNSET_VALUE


### PR DESCRIPTION
If xs.xs_port and xs.xs_use_ssl are set in the Vagrantfile, use these
parameters to communicate with the XenServer API.

Otherwise, default to port 80 without SSL/TLS (former behaviour).

Signed-off-by: Flavien Quesnel <flavien.quesnel@irt-systemx.fr>