### PR TITLE
Update nokogiri to at least 1.6.7

### DIFF
--- a/vagrant-xenserver.gemspec
+++ b/vagrant-xenserver.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description   = "Enables Vagrant to manage XenServers."
 
   s.add_development_dependency "rake"
-  s.add_runtime_dependency "nokogiri", "~> 1.6.3"
+  s.add_runtime_dependency "nokogiri", "~> 1.6.7"
   s.add_runtime_dependency "json"
 
   s.files         = `git ls-files`.split($\)


### PR DESCRIPTION
First off, sorry for the flood of pull requests I'm about to open. These are some changes that I made in order to get this plugin to work with our configuration. 

Nokogiri in ruby 2.2 does not support Windows, and vagrant recently just
merged a pull request to update the dependency to 1.6.7
(See https://github.com/mitchellh/vagrant/pull/6848 for more details)
This update enables people to use this plugin on windows with the most recent
versions of vagrant. This should wait to be merged until the patch for vagrant
is released.
