### PR TITLE
Added an api_timeout parameter to XMLRPC Client

### DIFF
--- a/lib/vagrant-xenserver/action/connect_xs.rb
+++ b/lib/vagrant-xenserver/action/connect_xs.rb
@@ -12,16 +12,17 @@ module VagrantPlugins
 
         def call(env)
           if not env[:session]
+            config = env[:machine].provider_config
             env[:xc] = XMLRPC::Client.new3({
-              'host' => env[:machine].provider_config.xs_host,
+              'host' => config.xs_host,
               'path' => "/",
-              'port' => env[:machine].provider_config.xs_port,
-              'use_ssl' => env[:machine].provider_config.xs_use_ssl
+              'port' => config.xs_port,
+              'use_ssl' => config.xs_use_ssl
             })
+            env[:xc].timeout = config.api_timeout unless config.api_timeout.nil?
             
             @logger.info("Connecting to XenServer")
-            
-            sess_result = env[:xc].call("session.login_with_password", env[:machine].provider_config.xs_username, env[:machine].provider_config.xs_password,"1.0")
+            sess_result = env[:xc].call("session.login_with_password", config.xs_username, config.xs_password,"1.0")
             
             if sess_result["Status"] != "Success"
               raise Errors::LoginError

--- a/lib/vagrant-xenserver/config.rb
+++ b/lib/vagrant-xenserver/config.rb
@@ -38,6 +38,11 @@ module VagrantPlugins
       # @return [Bool]
       attr_accessor :pv
 
+      # Timeout for commands sent to XenServer
+      #
+      # @return [Int]
+      attr_accessor :api_timeout
+
       # Memory settings
       #
       # @return [Int]
@@ -51,8 +56,9 @@ module VagrantPlugins
         @xs_password = UNSET_VALUE
         @name = UNSET_VALUE
         @pv = UNSET_VALUE
+        @api_timeout = UNSET_VALUE
         @memory = UNSET_VALUE
-	@xva_url = UNSET_VALUE
+        @xva_url = UNSET_VALUE
       end
 
       def finalize!
@@ -63,8 +69,9 @@ module VagrantPlugins
         @xs_password = nil if @xs_password == UNSET_VALUE
         @name = nil if @name == UNSET_VALUE
         @pv = nil if @pv == UNSET_VALUE
+        @api_timeout = 60 if @api_timeout = UNSET_VALUE
         @memory = 1024 if @memory == UNSET_VALUE
-	@xva_url = nil if @xva_url = UNSET_VALUE
+        @xva_url = nil if @xva_url = UNSET_VALUE
       end
 
       def validate(machine)


### PR DESCRIPTION
In cases where launching many machines in parallel, the XMLRPC Client's
default timeout of 30 seconds wasn't long enough. This adds an optional
parameter to increase the timeout.