### PR TITLE
Support MAC Address Network Parameter

### DIFF
--- a/lib/vagrant-xenserver/action/create_vifs.rb
+++ b/lib/vagrant-xenserver/action/create_vifs.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
 
             if type == :public_network then
               bridge = options[:bridge]
+              mac = options[:mac] || ''
 
               networks = env[:xc].call("network.get_all_records",env[:session])['Value']
 
@@ -31,7 +32,7 @@ module VagrantPlugins
                 'VM' => myvm,
                 'network' => net_ref,
                 'device' => vif_devices[0],
-                'MAC' => '',
+                'MAC' => mac,
                 'MTU' => '1500',
                 'other_config' => {},
                 'qos_algorithm_type' => '',


### PR DESCRIPTION
Vagrant allows the Vagrantfile to specify a MAC address as a parameter in
networking configuration and this passes that information on to XenServer.

(See http://stackoverflow.com/a/12604643/745719 for an example of this parameter)

Outstanding question:
This PR doesn't actually handle cases where the user doesn't put a delimiter in the MAC address such as ':' like the stackoverflow answer says to do. In my experience, Xen didn't set the MAC unless it was colon seperated. Should I add a little check to add in delimiters if the user leaves them out?