### PR TITLE
Fix running on OSX

### DIFF
--- a/lib/vagrant-xenserver/action/upload_vhd.rb
+++ b/lib/vagrant-xenserver/action/upload_vhd.rb
@@ -45,7 +45,11 @@ module VagrantPlugins
               @logger.info("box name=" + env[:machine].box.name.to_s)
               @logger.info("box version=" + env[:machine].box.version.to_s)
 
-              md5=`dd if=#{box_vhd_file} bs=1M count=1 | md5sum | cut '-d ' -f1`.strip
+              md5cmd = 'md5sum'
+              if `uname` =~ /^Darwin/
+                md5cmd = 'md5'
+              end
+              md5=`dd if=#{box_vhd_file} bs=1048576 count=1 | #{md5cmd} | cut '-d ' -f1`.strip
 
               @logger.info("md5=#{md5}")
 


### PR DESCRIPTION
OSX doesn't have `md5sum`. It has `md5`. In the perfect case we'd use `openssl md5`, which is likely to be everywhere, but for me it errored out around libssl.dylib. So I'm submitting `md5` vs `md5sum` detection.

Upon fixing that I've gotten:
```
$ vagrant up --provider=xenserver
Bringing machine 'default' up with 'xenserver' provider...
dd: bs: illegal numeric value
```

This is because OSX's `dd` likes `1m` more, instead of `1M`. Let's just use literal value of 1024*1024 here.