### PR TITLE
Fix createvif nilclass

### DIFF
--- a/lib/vagrant-xenserver/action/create_vifs.rb
+++ b/lib/vagrant-xenserver/action/create_vifs.rb
@@ -61,6 +61,10 @@ module VagrantPlugins
 
               netrefrec = networks.find { |ref,net| net['bridge']==bridge }
               (net_ref,net_rec) = netrefrec
+              if net_ref.nil? then
+                  @logger.error("Error finding bridge #{bridge} on host")
+                  raise Errors::NoHostsAvailable
+              end
 
               vif_res = create_vif(env, vm_ref, net_ref, mac)
 


### PR DESCRIPTION
I had only 1 NIC and 1 public network on my test host, and the `infrastructure` VM definition in `testarossa` wanted 2, failing like this when trying to access `xenbr1`:
```
/opt/vagrant/embedded/lib/ruby/2.2.0/xmlrpc/create.rb:202:in `conv2value': Wrong type NilClass. Not allowed! (RuntimeError)
	from /opt/vagrant/embedded/lib/ruby/2.2.0/xmlrpc/create.rb:226:in `block in conv2value'
	from /opt/vagrant/embedded/lib/ruby/2.2.0/xmlrpc/create.rb:223:in `each'
	from /opt/vagrant/embedded/lib/ruby/2.2.0/xmlrpc/create.rb:223:in `collect'
	from /opt/vagrant/embedded/lib/ruby/2.2.0/xmlrpc/create.rb:223:in `conv2value'
	from /opt/vagrant/embedded/lib/ruby/2.2.0/xmlrpc/create.rb:118:in `block in methodCall'
	from /opt/vagrant/embedded/lib/ruby/2.2.0/xmlrpc/create.rb:117:in `collect'
	from /opt/vagrant/embedded/lib/ruby/2.2.0/xmlrpc/create.rb:117:in `methodCall'
	from /opt/vagrant/embedded/lib/ruby/2.2.0/xmlrpc/client.rb:285:in `call2'
	from /opt/vagrant/embedded/lib/ruby/2.2.0/xmlrpc/client.rb:267:in `call'
	from /local/home/edwin/.vagrant.d/gems/2.2.5/gems/xenapi-0.2.11/lib/xenapi/client.rb:245:in `_do_call'
	from /local/home/edwin/.vagrant.d/gems/2.2.5/gems/xenapi-0.2.11/lib/xenapi/client.rb:180:in `_call'
	from /local/home/edwin/.vagrant.d/gems/2.2.5/gems/xenapi-0.2.11/lib/xenapi/dispatcher.rb:45:in `method_missing'
	from /local/home/edwin/.vagrant.d/gems/2.2.5/gems/vagrant-xenserver-0.0.13/lib/vagrant-xenserver/action/create_vifs.rb:30:in `create_vif'
	from /local/home/edwin/.vagrant.d/gems/2.2.5/gems/vagrant-xenserver-0.0.13/lib/vagrant-xenserver/action/create_vifs.rb:65:in `block in call'
	from /local/home/edwin/.vagrant.d/gems/2.2.5/gems/vagrant-xenserver-0.0.13/lib/vagrant-xenserver/action/create_vifs.rb:55:in `each'
	from /local/home/edwin/.vagrant.d/gems/2.2.5/gems/vagrant-xenserver-0.0.13/lib/vagrant-xenserver/action/create_vifs.rb:55:in `call'
```

Instead now you will get:
```
ERROR create_vifs: Error finding bridge xenbr1 on host
[...]
No hosts were available to start the VM. Check the memory, disks and whether the hosts are enabled
```