### PR TITLE
Disable ssh lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.18 (18 Nov 2024)
+* Disable ssh lock
+
 # 0.0.17 (18 Nov 2024)
 * Remove unused nokogiri dependency
 

--- a/lib/vagrant-xenserver/provider.rb
+++ b/lib/vagrant-xenserver/provider.rb
@@ -14,12 +14,12 @@ module VagrantPlugins
       end
 
       def ssh_info
-        env = @machine.action('read_ssh_info')
+        env = @machine.action('read_ssh_info', lock: false)
         env[:machine_ssh_info]
       end
 
       def state
-        env = @machine.action("read_state")
+        env = @machine.action("read_state", lock: false)
 
         state_id = env[:machine_state_id]
         

--- a/lib/vagrant-xenserver/version.rb
+++ b/lib/vagrant-xenserver/version.rb
@@ -1,6 +1,6 @@
 module VagrantPlugins
   module XenServer
-    VERSION = "0.0.17"
+    VERSION = "0.0.18"
   end
 end
 


### PR DESCRIPTION
This will disable the lock so that you can use `vagrant ssh` while `vagrant provision` is still running. We've used this for years on our local setup with no issues.

Also updated the version for a new release. Please also update https://rubygems.org/gems/vagrant-xenserver/ after tagging.